### PR TITLE
Fix a postinstall bug when running yarn remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "author": "Gerson Alexander Pardo Gamez  <jeral17@gmail.com>",
   "scripts": {
-    "postinstall": "cd ios && extract-zip Openpgp.framework.zip",
+    "postinstall": "cd ios && rm -rf Openpgp.framework && extract-zip Openpgp.framework.zip",
     "prepare": "npm run build",
     "build": "tsc",
     "watch": "tsc --watch",


### PR DESCRIPTION
I noticed there is a small but annoying bug when uninstalling another package with `yarn remove`.

The `postinstall` script from this library runs and you get an error like this:

<img width="708" alt="Screenshot 2020-07-13 at 18 30 59" src="https://user-images.githubusercontent.com/17656/87334810-24d47d00-c537-11ea-8118-a1d47f058f39.png">

The `yarn.lock` is then not updated as expected because yarn aborted its operation.

This is a simple fix: we just make sure that the `postinstall` can always succeed by removing any existing files before extracting. This can also fix a possible bug where installing a new version of the library may not update the framework binaries. `extract-zip` does not have an overwrite option: so we just use `rm -rf` (this will always succeed even if the file doesn't exist).